### PR TITLE
feat: promote USWDSFormMixin and USWDSFormRenderer to package root

### DIFF
--- a/demo_project/demo_app/forms.py
+++ b/demo_project/demo_app/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from django_cotton_uswds.mixins import USWDSFormMixin
+from django_cotton_uswds import USWDSFormMixin
 
 REASON_CHOICES = [
     ("", "- Select -"),

--- a/django_cotton_uswds/__init__.py
+++ b/django_cotton_uswds/__init__.py
@@ -3,3 +3,8 @@ try:
     from django_cotton_uswds._version import __version__
 except ImportError:
     __version__ = "0.0.0.dev0"
+
+from django_cotton_uswds.mixins import USWDSFormMixin
+from django_cotton_uswds.renderer import USWDSFormRenderer
+
+__all__ = ["USWDSFormMixin", "USWDSFormRenderer"]

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -421,6 +421,34 @@ class TestGlobalFormRendererSetting:
         assert "usa-input" in html
 
 
+class TestPackageRootImports:
+    def test_uswds_form_mixin_importable_from_package_root(self):
+        from django_cotton_uswds import USWDSFormMixin  # noqa: F401
+
+    def test_uswds_form_renderer_importable_from_package_root(self):
+        from django_cotton_uswds import USWDSFormRenderer  # noqa: F401
+
+    def test_all_exports_both_names(self):
+        import django_cotton_uswds
+
+        assert "USWDSFormMixin" in django_cotton_uswds.__all__
+        assert "USWDSFormRenderer" in django_cotton_uswds.__all__
+
+    def test_short_form_renderer_setting_activates_uswds_rendering(self, settings):
+        settings.FORM_RENDERER = "django_cotton_uswds.USWDSFormRenderer"
+
+        form = SimpleForm()
+        html = form.render()
+
+        assert "usa-form-group" in html
+        assert "usa-label" in html
+        assert "usa-input" in html
+
+    def test_deep_import_paths_still_work(self):
+        from django_cotton_uswds.mixins import USWDSFormMixin  # noqa: F401
+        from django_cotton_uswds.renderer import USWDSFormRenderer  # noqa: F401
+
+
 class TestUSWDSFormMixin:
     def test_mixin_renders_uswds_structure(self):
         from django_cotton_uswds.mixins import USWDSFormMixin


### PR DESCRIPTION
## Summary

- Re-exports `USWDSFormMixin` and `USWDSFormRenderer` from `django_cotton_uswds/__init__.py`
- Defines `__all__` with both names
- Enables `FORM_RENDERER = "django_cotton_uswds.USWDSFormRenderer"` (short path)
- Deep import paths remain functional for backward compatibility

Closes #11

## Test plan

- [ ] `from django_cotton_uswds import USWDSFormMixin` works
- [ ] `from django_cotton_uswds import USWDSFormRenderer` works
- [ ] `__all__` contains both names
- [ ] Short `FORM_RENDERER` setting activates USWDS rendering
- [ ] Deep import paths still work
- [ ] All 73 existing tests pass