### PR TITLE
Fix static site generation on gh pages and add a test

### DIFF
--- a/.github/actions/build-test-static/action.yml
+++ b/.github/actions/build-test-static/action.yml
@@ -1,0 +1,39 @@
+name: 'Build and Test Github Pages Site'
+description: 'Build and Test Github Pages Site'
+runs:
+  using: "composite"
+  steps:
+    - name: Collect static files
+      working-directory: demo_project
+      run: uv run python manage.py collectstatic --noinput
+      shell: bash
+      env:
+          STATIC_URL: /django-cotton-uswds/static/
+          URL_PREFIX: /django-cotton-uswds
+
+    - name: Build static site
+      working-directory: demo_project
+      run: uv run python manage.py distill-local dist --force
+      shell: bash
+      env:
+          STATIC_URL: /django-cotton-uswds/static/
+          URL_PREFIX: /django-cotton-uswds
+
+    - name: Fix static paths for GitHub Pages
+      shell: bash
+      run: |
+          mv demo_project/dist/django-cotton-uswds/static demo_project/dist/static
+          rm -rf demo_project/dist/django-cotton-uswds
+
+    - name: Test static site assets
+      working-directory: demo_project
+      shell: bash
+      run: |
+        ln -s ./dist ./django-cotton-uswds
+        python -m http.server 8005 &
+        sleep 2
+        curl -I -f http://localhost:8005/django-cotton-uswds/render-pattern/patterns/components/accordion/accordion.html
+        curl -I -f http://localhost:8005/django-cotton-uswds/static/pattern_library/dist/bundle.js
+      env:
+        STATIC_URL: /django-cotton-uswds/static/
+        URL_PREFIX: /django-cotton-uswds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,9 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+      - name: Test github pages static site
+        uses: ./.github/actions/build-test-static
+
+
+          

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,13 +25,8 @@ jobs:
 
       - run: uv sync --extra dev
 
-      - name: Collect static files
-        working-directory: demo_project
-        run: uv run python manage.py collectstatic --noinput
-
-      - name: Build static site
-        working-directory: demo_project
-        run: uv run python manage.py distill-local dist --force
+      - name: Build and test github pages static site
+        uses: ./.github/actions/build-test-static
 
       - uses: actions/configure-pages@v5
 

--- a/uv.lock
+++ b/uv.lock
@@ -179,18 +179,20 @@ dependencies = [
     { name = "django", version = "5.2.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "django-cotton" },
-    { name = "django-pattern-library" },
 ]
 
 [package.optional-dependencies]
 demo = [
     { name = "django-distill" },
+    { name = "django-pattern-library" },
 ]
 dev = [
     { name = "django-distill" },
+    { name = "django-pattern-library" },
     { name = "ruff" },
 ]
 test = [
+    { name = "django-pattern-library" },
     { name = "pytest" },
     { name = "pytest-django" },
 ]
@@ -201,7 +203,9 @@ requires-dist = [
     { name = "django-cotton", specifier = ">=1.2.1" },
     { name = "django-distill", marker = "extra == 'demo'", specifier = ">=3.0.0" },
     { name = "django-distill", marker = "extra == 'dev'", specifier = ">=3.0.0" },
-    { name = "django-pattern-library", specifier = ">=1.5.0" },
+    { name = "django-pattern-library", marker = "extra == 'demo'", specifier = ">=1.5.0" },
+    { name = "django-pattern-library", marker = "extra == 'dev'", specifier = ">=1.5.0" },
+    { name = "django-pattern-library", marker = "extra == 'test'", specifier = ">=1.5.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
     { name = "pytest-django", marker = "extra == 'test'", specifier = ">=4.8" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },


### PR DESCRIPTION
This PR fixes the static site generation logic by adding a reusable action and including a test during the github pages upload.