### PR TITLE
Add Markdown functionality to alert component

### DIFF
--- a/django_cotton_uswds/templates/cotton/alert/index.html
+++ b/django_cotton_uswds/templates/cotton/alert/index.html
@@ -5,6 +5,7 @@
     extra_classes=""
     role=""
     :slim="False"
+    :rich="False"
 />
 
 <div class="usa-alert usa-alert--{{ type }} {{ extra_classes }} {% if slim %}usa-alert--slim{% endif %}"
@@ -19,9 +20,15 @@
     {% endif %}
 
     {# Body content (variable or slot) #}
-    <p class="usa-alert__text">
-      {{ slot|safe }}
-    </p>
+    {% if rich %}
+      <div class="usa-alert__text usa-prose">
+        {{ slot|safe }}
+      </div>
+    {% else %}
+      <p class="usa-alert__text">
+        {{ slot|safe }}
+      </p>
+    {% endif %}
 
   </div>
 

--- a/django_cotton_uswds/templates/patterns/components/alert/alert.html
+++ b/django_cotton_uswds/templates/patterns/components/alert/alert.html
@@ -7,11 +7,12 @@
     <div class="component-variant">
         <h2 class="variant-title">{{ variant.title }}</h2>
         
-        <c-alert 
+        <c-alert
             type="{{ variant.type }}"
             heading="{{ variant.heading }}"
             role="{{ variant.role }}"
-            extra_classes="{{ variant.extra_classes }}">
+            extra_classes="{{ variant.extra_classes }}"
+            :rich="{{ variant.rich|default:'False' }}">
             {{ variant.content|safe }}
         </c-alert>
     </div>

--- a/django_cotton_uswds/templates/patterns/components/alert/alert.md
+++ b/django_cotton_uswds/templates/patterns/components/alert/alert.md
@@ -9,7 +9,9 @@ A contextual notification that informs users of a status change or action they n
 | `type`         | `info`  | Alert type: `info`, `warning`, `success`, `error`, or `emergency`                                |
 | `heading`      |         | Optional heading text displayed above the body content                                            |
 | `role`         |         | ARIA role override; automatically set to `alert` for `error` and `emergency` types               |
-| `extra_classes`|         | Additional CSS classes (e.g., `usa-alert--slim`, `usa-alert--no-icon`)                           |
+| `extra_classes`|         | Additional CSS classes (e.g., `usa-alert--no-icon`)                                              |
+| `:slim`        | `False` | Renders the compact slim variant (adds `usa-alert--slim`)                                        |
+| `:rich`        | `False` | Wraps the body in a `usa-prose` `<div>` instead of a single `<p>` so the slot can contain multiple block elements (paragraphs, lists, headings) |
 
 ## Slots
 
@@ -75,9 +77,25 @@ A contextual notification that informs users of a status change or action they n
 </c-alert>
 ```
 
+### Rich Content Alert
+
+Use `:rich="True"` when the body needs to contain multiple block elements such as paragraphs or lists. The slot is rendered inside a `usa-prose` `<div>` rather than a single `<p>`.
+
+```django
+<c-alert type="info" heading="Rich content status" :rich="True">
+    <p>Lorem ipsum dolor sit amet, <a class="usa-link" href="#">consectetur adipiscing</a> elit.</p>
+    <ul>
+        <li>First supporting detail</li>
+        <li>Second supporting detail</li>
+    </ul>
+    <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+</c-alert>
+```
+
 ## Usage Notes
 
 - The `error` and `emergency` types automatically set `role="alert"` for screen readers
-- Use the slim variant (`extra_classes="usa-alert--slim"`) for compact notifications that don't need a heading
+- Use `:slim="True"` for compact notifications that don't need a heading
+- Set `:rich="True"` when the body needs multiple block-level elements; otherwise the default `<p>` wrapper is preferred
 - Body content is passed as the slot and supports safe HTML rendering
 - For sitewide alerts that wrap the full page width, use the `c-site_alert` component instead

--- a/django_cotton_uswds/templates/patterns/components/alert/alert.yaml
+++ b/django_cotton_uswds/templates/patterns/components/alert/alert.yaml
@@ -49,3 +49,17 @@ context:
       role: ""
       extra_classes: "usa-alert--no-icon"
       content: 'No icon example'
+
+    - title: "Rich content alert"
+      type: "info"
+      heading: "Rich content status"
+      role: ""
+      extra_classes: ""
+      rich: True
+      content: |
+        <p>Lorem ipsum dolor sit amet, <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a> elit.</p>
+        <ul>
+          <li>First supporting detail</li>
+          <li>Second supporting detail</li>
+        </ul>
+        <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -127,6 +127,7 @@ def test_get_component_returns_local_docs():
     assert "Props" in result
     assert "type" in result
     assert "heading" in result
+    assert ":rich" in result
 
 
 def test_get_component_unknown():


### PR DESCRIPTION
Wraps the alert body in a usa-prose div instead of a single <p> when :rich="True", so the slot can contain multiple block elements (paragraphs, lists, headings). Pattern library variant, docs, and MCP doc test updated to cover the new prop.