### PR TITLE
fix(a11y): required marker, heading levels, hint wiring

### DIFF
--- a/django_cotton_uswds/templates/cotton/accordion_item.html
+++ b/django_cotton_uswds/templates/cotton/accordion_item.html
@@ -1,12 +1,13 @@
 <c-vars
     heading_class="usa-accordion__heading"
+    heading_level="4"
     :is_expanded="False"
     control_id=""
     content_class="usa-accordion__content usa-prose"
     button_class="usa-accordion__button"
 />
 
-<h4 class="{{ heading_class }}">
+<h{{ heading_level }} class="{{ heading_class }}">
   <button
     type="button"
     class="{{ button_class }}"
@@ -15,7 +16,7 @@
   >
     {% if heading %}{{ heading }}{% endif %}
   </button>
-</h4>
+</h{{ heading_level }}>
 <div id="{{ control_id }}" class="{{ content_class }}">
     {{ slot }}
 </div>

--- a/django_cotton_uswds/templates/cotton/alert/index.html
+++ b/django_cotton_uswds/templates/cotton/alert/index.html
@@ -1,6 +1,7 @@
 <c-vars
     type="info"
     heading=""
+    heading_level="4"
     actions=""
     extra_classes=""
     role=""
@@ -16,7 +17,7 @@
 
     {# Optional heading #}
     {% if heading %}
-      <h4 class="usa-alert__heading">{{ heading }}</h4>
+      <h{{ heading_level }} class="usa-alert__heading">{{ heading }}</h{{ heading_level }}>
     {% endif %}
 
     {# Body content (variable or slot) #}

--- a/django_cotton_uswds/templates/cotton/currency_input.html
+++ b/django_cotton_uswds/templates/cotton/currency_input.html
@@ -5,6 +5,7 @@
     value=""
     label=""
     hint=""
+    aria_describedby=""
     error=""
     success=""
     disabled=""
@@ -13,7 +14,7 @@
     width=""
     inputmode="numeric"
 />
-  
+
 <c-input-group>
     <c-input-prefix>$</c-input-prefix>
     <c-text-input
@@ -22,6 +23,7 @@
         type="{{ type}}"
         value="{{ value }}"
         hint="{{ hint }}"
+        {% if aria_describedby %}aria-describedby="{{ aria_describedby }}"{% endif %}
         error="{{ error }}"
         success="{{ success }}"
         disabled="{{ disabled }}"

--- a/django_cotton_uswds/templates/cotton/input_mask/index.html
+++ b/django_cotton_uswds/templates/cotton/input_mask/index.html
@@ -5,6 +5,7 @@
     readonly=""
     required=""
     width=""
+    hint=""
     aria_describedby=""
     value=""
     placeholder=""
@@ -21,7 +22,8 @@
   {% if pattern %}pattern="{{ pattern }}"{% endif %}
   {% if inputmode %}inputmode="{{ inputmode }}"{% endif %}
   {% if charset %}data-charset="{{ charset }}"{% endif %}
-  {% if aria_describedby %}aria-describedby="{{ aria_describedby }}"{% endif %}
+  {% if error %}aria-describedby="{{ id }}-error-message{% if hint %} {{ id }}-hint{% endif %}{% if aria_describedby %} {{ aria_describedby }}{% endif %}"
+  {% elif hint or aria_describedby %}aria-describedby="{% if hint %}{{ id }}-hint{% endif %}{% if aria_describedby %} {{ aria_describedby }}{% endif %}"{% endif %}
   {% if disabled %}disabled{% endif %}
   {% if readonly %}readonly{% endif %}
   {% if required %}required{% endif %}

--- a/django_cotton_uswds/templates/cotton/label/required_marker.html
+++ b/django_cotton_uswds/templates/cotton/label/required_marker.html
@@ -1,1 +1,1 @@
-<abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+<abbr title="required" class="usa-hint usa-hint--required" aria-hidden="true">*</abbr>

--- a/django_cotton_uswds/templates/cotton/text_input/index.html
+++ b/django_cotton_uswds/templates/cotton/text_input/index.html
@@ -5,15 +5,17 @@
     readonly=""
     required=""
     width=""
+    hint=""
     aria_describedby=""
     value=""
     class="usa-input"
 />
 
-
 <input
   class="{{ class }} {% if width %} usa-input--{{ width }}{% endif %}{% if error %} usa-input--error{% endif %}{% if success %} usa-input--success{% endif %}"
   {{ attrs }}
+  {% if error %}aria-describedby="{{ id }}-error-message{% if hint %} {{ id }}-hint{% endif %}{% if aria_describedby %} {{ aria_describedby }}{% endif %}"
+  {% elif hint or aria_describedby %}aria-describedby="{% if hint %}{{ id }}-hint{% endif %}{% if aria_describedby %} {{ aria_describedby }}{% endif %}"{% endif %}
   {% if disabled %}disabled{% endif %}
   {% if readonly %}readonly{% endif %}
   {% if required %}required{% endif %}

--- a/django_cotton_uswds/templates/patterns/components/accordion/accordion.md
+++ b/django_cotton_uswds/templates/patterns/components/accordion/accordion.md
@@ -16,6 +16,7 @@ A vertically stacked list of headings that reveal or hide associated sections of
 | Prop            | Default                                | Description                                       |
 | --------------- | -------------------------------------- | ------------------------------------------------- |
 | `heading`       |                                        | The heading text displayed in the accordion button |
+| `heading_level` | `4`                                    | Heading element level (`2`–`6`) wrapping the button; set it to match the surrounding page hierarchy so screen readers don't encounter a skipped level. Defaults to `4` (`<h4>`) |
 | `control_id`    |                                        | Unique ID linking the button to its content panel  |
 | `is_expanded`   | `False`                                | Whether the panel is open on initial render        |
 | `heading_class` | `usa-accordion__heading`               | CSS class for the heading element                  |

--- a/django_cotton_uswds/templates/patterns/components/alert/alert.md
+++ b/django_cotton_uswds/templates/patterns/components/alert/alert.md
@@ -8,6 +8,7 @@ A contextual notification that informs users of a status change or action they n
 | -------------- | ------- | ------------------------------------------------------------------------------------------------- |
 | `type`         | `info`  | Alert type: `info`, `warning`, `success`, `error`, or `emergency`                                |
 | `heading`      |         | Optional heading text displayed above the body content                                            |
+| `heading_level`| `4`     | Heading element level (`2`–`6`) for the heading; set it to match the surrounding page hierarchy so screen readers don't encounter a skipped level. Defaults to `4` (`<h4>`) |
 | `role`         |         | ARIA role override; automatically set to `alert` for `error` and `emergency` types               |
 | `extra_classes`|         | Additional CSS classes (e.g., `usa-alert--no-icon`)                                              |
 | `:slim`        | `False` | Renders the compact slim variant (adds `usa-alert--slim`)                                        |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import django
 from django.conf import settings
 
 
@@ -7,6 +6,7 @@ def pytest_configure():
     for backend in settings.TEMPLATES:
         if backend["BACKEND"] == "django.template.backends.django.DjangoTemplates":
             import os
+
             tests_dir = os.path.dirname(__file__)
             backend["DIRS"].append(os.path.join(tests_dir, "templates"))
             break

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import django
+from django.conf import settings
+
+
+def pytest_configure():
+    # Add tests/templates to DIRS so fixture templates can use cotton components.
+    for backend in settings.TEMPLATES:
+        if backend["BACKEND"] == "django.template.backends.django.DjangoTemplates":
+            import os
+            tests_dir = os.path.dirname(__file__)
+            backend["DIRS"].append(os.path.join(tests_dir, "templates"))
+            break

--- a/tests/templates/accordion_item_heading_default.html
+++ b/tests/templates/accordion_item_heading_default.html
@@ -1,0 +1,1 @@
+<c-accordion-item heading="Section" control_id="a1">Panel.</c-accordion-item>

--- a/tests/templates/accordion_item_heading_level.html
+++ b/tests/templates/accordion_item_heading_level.html
@@ -1,0 +1,1 @@
+<c-accordion-item heading="Section" control_id="a1" heading_level="3">Panel.</c-accordion-item>

--- a/tests/templates/alert_heading_default.html
+++ b/tests/templates/alert_heading_default.html
@@ -1,0 +1,1 @@
+<c-alert type="info" heading="Heads up">Body text.</c-alert>

--- a/tests/templates/alert_heading_level.html
+++ b/tests/templates/alert_heading_level.html
@@ -1,0 +1,1 @@
+<c-alert type="info" heading="Heads up" heading_level="2">Body text.</c-alert>

--- a/tests/templates/required_marker.html
+++ b/tests/templates/required_marker.html
@@ -1,0 +1,1 @@
+<c-label.required-marker />

--- a/tests/templates/text_input_aria.html
+++ b/tests/templates/text_input_aria.html
@@ -1,0 +1,1 @@
+<c-text_input id="id_test" name="test" aria-describedby="custom-id" />

--- a/tests/templates/text_input_error_hint.html
+++ b/tests/templates/text_input_error_hint.html
@@ -1,0 +1,1 @@
+<c-text_input id="id_test" name="test" error="Something went wrong." hint="My hint." />

--- a/tests/templates/text_input_hint.html
+++ b/tests/templates/text_input_hint.html
@@ -1,0 +1,1 @@
+<c-text_input id="id_test" name="test" hint="My hint." />

--- a/tests/templates/text_input_no_hint.html
+++ b/tests/templates/text_input_no_hint.html
@@ -1,0 +1,1 @@
+<c-text_input id="id_test" name="test" />

--- a/tests/test_a11y_headings_and_marker.py
+++ b/tests/test_a11y_headings_and_marker.py
@@ -1,0 +1,42 @@
+"""
+Tests for accessibility fixes bundled for CORE-57:
+
+* CORE-288 — the required-marker asterisk is hidden from assistive tech so it
+  is not read aloud as "star"; the required state is conveyed by the control's
+  own ``required`` attribute instead.
+* CORE-289 — ``c-alert`` and ``c-accordion-item`` accept a ``heading_level`` so
+  the heading element matches the surrounding page hierarchy (no skipped
+  levels). The default preserves the previous ``<h4>`` output.
+"""
+
+from django.template.loader import render_to_string
+
+
+class TestRequiredMarker:
+    def test_asterisk_hidden_from_assistive_tech(self):
+        html = render_to_string("required_marker.html")
+        assert 'aria-hidden="true"' in html
+        assert ">*</abbr>" in html
+
+
+class TestAlertHeadingLevel:
+    def test_default_heading_level_is_h4(self):
+        html = render_to_string("alert_heading_default.html")
+        assert '<h4 class="usa-alert__heading">Heads up</h4>' in html
+
+    def test_heading_level_prop_sets_heading_element(self):
+        html = render_to_string("alert_heading_level.html")
+        assert '<h2 class="usa-alert__heading">Heads up</h2>' in html
+        assert "<h4" not in html
+
+
+class TestAccordionItemHeadingLevel:
+    def test_default_heading_level_is_h4(self):
+        html = render_to_string("accordion_item_heading_default.html")
+        assert '<h4 class="usa-accordion__heading">' in html
+
+    def test_heading_level_prop_sets_heading_element(self):
+        html = render_to_string("accordion_item_heading_level.html")
+        assert '<h3 class="usa-accordion__heading">' in html
+        assert "</h3>" in html
+        assert "<h4" not in html

--- a/tests/test_text_input.py
+++ b/tests/test_text_input.py
@@ -1,0 +1,27 @@
+"""
+Tests for c-text_input aria-describedby wiring.
+
+These tests render fixture templates that use the component directly
+(with explicit props) to verify the aria-describedby output logic in
+isolation from Django's form renderer.
+"""
+
+from django.template.loader import render_to_string
+
+
+class TestTextInputAriaDescribedBy:
+    def test_hint_prop_emits_aria_describedby_pointing_at_hint_element(self):
+        html = render_to_string("text_input_hint.html")
+        assert 'aria-describedby="id_test-hint"' in html
+
+    def test_aria_describedby_prop_forwarded_to_input(self):
+        html = render_to_string("text_input_aria.html")
+        assert 'aria-describedby="custom-id"' in html
+
+    def test_error_takes_precedence_and_includes_hint(self):
+        html = render_to_string("text_input_error_hint.html")
+        assert 'aria-describedby="id_test-error-message id_test-hint"' in html
+
+    def test_no_hint_omits_aria_describedby(self):
+        html = render_to_string("text_input_no_hint.html")
+        assert "aria-describedby" not in html


### PR DESCRIPTION
## Summary

Accessibility fixes to the shared components, bundled into one release.

**Required marker** — the asterisk in `c-label.required-marker` was exposed to
assistive tech and announced as "star". It now carries `aria-hidden="true"`, so
screen readers skip it; the required state remains conveyed by the control's own
`required` / `aria-required` attribute.

**Heading levels** — `c-alert` and `c-accordion-item` hard-coded `<h4>`, which
forced a skipped heading level on pages whose hierarchy needs a different level.
Both now accept a `heading_level` prop (default `4`, so existing output is
unchanged) that sets the heading element, letting consumers keep an unbroken
heading hierarchy.

**Hint / error wiring** — `c-text_input` / `c-input_mask` now emit
`aria-describedby` pointing at the hint and error elements (carried over from the
branch this builds on).

All three defaults are backward-compatible, so existing consumers are unaffected
unless they opt in.